### PR TITLE
Arrow keys in NumberFields do not scroll the interactive

### DIFF
--- a/editor.js
+++ b/editor.js
@@ -176,13 +176,9 @@ export class InteractivesEditor extends Morph {
 
   inputFieldFocused () {
     const focusedMorph = this.env.eventDispatcher.eventState.focusedMorph; // TODO: This could be done with a utility in EventDispatcher
-    if (focusedMorph) {
-      const className = focusedMorph.constructor.name;
-      if (this.inputFieldClasses.includes(className)) {
-        return true;
-      }
-    }
-    return false;
+    if (!focusedMorph) return false;
+    const className = focusedMorph.constructor.name;
+    return this.inputFieldClasses.includes(className);
   }
 
   get commands () {


### PR DESCRIPTION
Co-authored-by: linusha <linusha@users.noreply.github.com>

Closes #185 

Does not touch any other features.

