### PR TITLE
Feature/snapping

### DIFF
--- a/timeline.js
+++ b/timeline.js
@@ -968,8 +968,8 @@ export class TimelineSequence extends Morph {
     const dragDelta = this.leftResizer.position.x;
     const newSequenceWidth = sequenceState.previousWidth - dragDelta;
     // stop resizing due to minimal width
-    if (newSequenceWidth <= CONSTANTS.MINIMAL_SEQUENCE_WIDTH) {
-      this.showWarningLeft(Math.abs(dragDelta));
+    if (newSequenceWidth < CONSTANTS.MINIMAL_SEQUENCE_WIDTH) {
+      this.showWarningLeft(-dragDelta);
       this.extent = pt(CONSTANTS.MINIMAL_SEQUENCE_WIDTH, this.height);
       this.position = pt(sequenceState.previousTopRight.x - CONSTANTS.MINIMAL_SEQUENCE_WIDTH, CONSTANTS.SEQUENCE_LAYER_Y_OFFSET);
     }


### PR DESCRIPTION
Closes #46 

## Features that still work:
### Sequences in GlobalTimeline:

- [x] the tree sequence is resizeable both left and right
- [x] the day sequence can't be dragged or resized onto the night sequence
- [x] the night sequence can't be dragged or resized beyond the timeline bounds
- [x] double clicking on the sky sequence brings you to the sequence view

### TimelineLayer:

- [x] one can bring the background layer to the front via drag and drop and the tree is not visible afterwards
- [x] the info labels change accordingly

### TimelineCursor:

- [x] scrolls when scrolling in the interactive
- [x] with open interactive, scroll position (and cursor position) may be changed with arrow keys

### Interactive:

- [x] can be opened
- [x] is scrollable
- [x] can be loaded in the editor via drag and drop

### Sequence View:

- [x] there are two OverviewLayers (one per Morph in the sequence)
- [x] they hold four Keyframes each
- [x] right-clicking a keyframe shows a context menu
- [x] clicking on the triangle expands those into two new layers with two keyframes each
- [ ] when expanding both morphs the cursor is still visible over all layers
- [x] creating a new keyframe (with the inspector) will update the layers accordingly
- [x] pressing ESC brings one back to the GlobalTimeline

### Inspector:

- [ ] the tree leaves can be selected to inspect with the target selector
- [ ] correct values for position, extent and opacity are shown
- [ ] when setting two keyframes for different position values at different scroll positions, an animation is created and can be viewed
- [ ] when scrolling in the scrollytelling, created keyframes are shown by a different icon in the inspector
- [ ] a keyframe can be overwritten in the inspector by navigating to the same scroll position (most easily done at scroll position 0) and adding a new keyframe

