### PR TITLE
Limit movement with arrow keys to interactive length

### DIFF
--- a/editor.js
+++ b/editor.js
@@ -203,7 +203,7 @@ export class InteractivesEditor extends Morph {
         name: 'move scrollposition forward',
         doc: 'Move the scrollPosition of the interactive forward by one unit',
         exec: () => {
-          if (this.interactive && !this.inputFieldFocused()) {
+          if (this.interactive && !this.inputFieldFocused() && this.interactive.scrollPosition < this.interactive.length) {
             this.interactive.scrollPosition++;
           }
         }
@@ -212,7 +212,7 @@ export class InteractivesEditor extends Morph {
         name: 'move scrollposition backwards',
         doc: 'Move the scrollPosition of the interactive back by one unit',
         exec: () => {
-          if (this.interactive && !this.inputFieldFocused()) {
+          if (this.interactive && !this.inputFieldFocused() && this.interactive.scrollPosition > 0) {
             this.interactive.scrollPosition--;
           }
         }


### PR DESCRIPTION
Closes #196 

## Features that still work:
### Sequences in GlobalTimeline:

- [ ] the tree sequence is resizeable both left and right
- [ ] the day sequence can't be dragged or resized onto the night sequence
- [ ] the night sequence can't be dragged or resized beyond the timeline bounds
- [ ] double clicking on the sky sequence brings you to the sequence view

### TimelineLayer:

- [ ] one can bring the background layer to the front via drag and drop and the tree is not visible afterwards
- [ ] the info labels change accordingly

### TimelineCursor:

- [ ] scrolls when scrolling in the interactive
- [x] with open interactive, scroll position (and cursor position) may be changed with arrow keys

### Interactive:

- [ ] can be opened
- [ ] is scrollable
- [ ] can be loaded in the editor via drag and drop

### Sequence View:

- [ ] there are two OverviewLayers (one per Morph in the sequence)
- [ ] they hold four Keyframes each
- [ ] right-clicking a keyframe shows a context menu
- [ ] clicking on the triangle expands those into two new layers with two keyframes each
- [ ] when expanding both morphs the cursor is still visible over all layers
- [ ] creating a new keyframe (with the inspector) will update the layers accordingly
- [ ] pressing ESC brings one back to the GlobalTimeline

### Inspector:

- [ ] the tree leaves can be selected to inspect with the target selector
- [ ] correct values for position, extent and opacity are shown
- [ ] when setting two keyframes for different position values at different scroll positions, an animation is created and can be viewed
- [ ] when scrolling in the scrollytelling, created keyframes are shown by a different icon in the inspector
- [ ] a keyframe can be overwritten in the inspector by navigating to the same scroll position (most easily done at scroll position 0) and adding a new keyframe

