### PR TITLE
Add right click menu for sequences

### DIFF
--- a/interactive.js
+++ b/interactive.js
@@ -123,7 +123,7 @@ export class Interactive extends Morph {
   }
 
   getSequencesInLayerBetween (layer, start, end) {
-    return this.getSequencesInLayer(layer).filter(sequence => (sequence.end >= start && sequence.end <= end) || (sequence.start <= end && sequence.start >= start));
+    return this.getSequencesInLayer(layer).filter(sequence => (sequence.end >= start && sequence.end <= end) || (sequence.start >= start && sequence.start <= end));
   }
 
   getSequenceInLayerAfter (sequence) {
@@ -151,6 +151,22 @@ export class Interactive extends Morph {
     disconnectAll(sequence);
     arr.remove(this.sequences, sequence);
     sequence.remove();
+  }
+
+  validSequenceStart (sequence, start) {
+    if (start == undefined || start == null || isNaN(start)) return false;
+    if (start < 0) return false;
+    return this.getSequencesInLayerBetween(sequence.layer, start, start + sequence.duration).filter(s => s != sequence).length === 0;
+  }
+
+  validSequenceDuration (sequence, duration) {
+    if (duration == undefined || duration == null || isNaN(duration)) return false;
+    if (duration < 1) return false;
+    const nextSequence = this.getSequenceInLayerAfter(sequence);
+    if (nextSequence) {
+      return nextSequence.start >= sequence.start + duration;
+    }
+    return true;
   }
 
   showOnly (sequence) {
@@ -457,21 +473,5 @@ export class Sequence extends Morph {
 
   getAnimationsForMorph (morph) {
     return this.animations.filter(animation => animation.target === morph);
-  }
-
-  isValidStart (start) {
-    if (start == undefined || start == null || isNaN(start)) return false;
-    if (start < 0) return false;
-    return this.interactive.getSequencesInLayerBetween(this.layer, start, start + this.duration).filter(sequence => sequence != this).length === 0;
-  }
-
-  isValidDuration (duration) {
-    if (duration == undefined || duration == null || isNaN(duration)) return false;
-    if (duration < 1) return false;
-    const nextSequence = this.interactive.getSequenceInLayerAfter(this);
-    if (nextSequence) {
-      return nextSequence.start >= this.start + duration;
-    }
-    return true;
   }
 }

--- a/tests/sequence-test.js
+++ b/tests/sequence-test.js
@@ -125,17 +125,17 @@ describe('Sequence object', () => {
     });
 
     it('can determine valid starts', () => {
-      expect(sequence.isValidStart(undefined)).to.not.be.ok;
-      expect(sequence.isValidStart(0)).to.be.ok;
-      expect(sequence.isValidStart(45)).to.not.be.ok; // Would intersect with anotherSequence
-      expect(sequence.isValidStart(-1)).to.not.be.ok;
+      expect(interactive.validSequenceStart(sequence, undefined)).to.not.be.ok;
+      expect(interactive.validSequenceStart(sequence, 0)).to.be.ok;
+      expect(interactive.validSequenceStart(sequence, 45)).to.not.be.ok; // Would intersect with anotherSequence
+      expect(interactive.validSequenceStart(sequence, -1)).to.not.be.ok;
     });
 
     it('can determine valid durations', () => {
-      expect(sequence.isValidDuration(NaN)).to.not.be.ok;
-      expect(sequence.isValidDuration(10)).to.be.ok;
-      expect(sequence.isValidDuration(70)).to.not.be.ok; // Would intersect with anotherSequence
-      expect(sequence.isValidDuration(-1)).to.not.be.ok;
+      expect(interactive.validSequenceDuration(sequence, NaN)).to.not.be.ok;
+      expect(interactive.validSequenceDuration(sequence, 10)).to.be.ok;
+      expect(interactive.validSequenceDuration(sequence, 70)).to.not.be.ok; // Would intersect with anotherSequence
+      expect(interactive.validSequenceDuration(sequence, -1)).to.not.be.ok;
     });
   });
 });

--- a/timeline/sequence.js
+++ b/timeline/sequence.js
@@ -467,7 +467,7 @@ export class TimelineSequence extends Morph {
       ['Edit duration', async () => await this.promptDuration()],
       ['Edit start position', async () => await this.promptStart()],
       { isDivider: true },
-      ['Open sequence view', () => this.openSequenceView()],
+      ['View sequence', () => this.openSequenceView()],
       ['Go to start', () => this.editor.interactiveScrollPosition = this.sequence.start]
     ];
   }
@@ -476,13 +476,12 @@ export class TimelineSequence extends Morph {
     const newName = await $world.prompt('Sequence name:', { input: this.sequence.name });
     if (newName) {
       this.sequence.name = newName;
-      this.caption = newName;
     }
   }
 
   async promptDuration () {
     const newDuration = Number(await $world.prompt('Duration:', { input: this.sequence.duration }));
-    if (this.sequence.isValidDuration(newDuration)) {
+    if (this.editor.interactive.validSequenceDuration(this.sequence, newDuration)) {
       this.sequence.duration = newDuration;
       this.width = this.timeline.getWidthFromDuration(newDuration);
     } else {
@@ -492,7 +491,7 @@ export class TimelineSequence extends Morph {
 
   async promptStart () {
     const newStart = Number(await $world.prompt('Start:', { input: this.sequence.start }));
-    if (this.sequence.isValidStart(newStart)) {
+    if (this.editor.interactive.validSequenceStart(this.sequence, newStart)) {
       this.sequence.start = newStart;
       this.position = pt(this.timeline.getPositionFromScroll(newStart), CONSTANTS.SEQUENCE_LAYER_Y_OFFSET);
     } else {
@@ -503,10 +502,10 @@ export class TimelineSequence extends Morph {
   delete () {
     this.remove();
 
-    const sequenceView = this.editor.getTabFor(this.sequence);
-    if (sequenceView) {
-      this.editor.disbandTabConnections(sequenceView);
-      sequenceView.close();
+    const sequenceTab = this.editor.getTabFor(this.sequence);
+    if (sequenceTab) {
+      this.editor.disbandTabConnections(sequenceTab);
+      sequenceTab.close();
     }
 
     this.editor.interactive.removeSequence(this.sequence);


### PR DESCRIPTION
Closes #220 

## Features that still work:
### Sequences in GlobalTimeline:

- [ ] the tree sequence is resizeable both left and right
- [ ] the day sequence can't be dragged or resized onto the night sequence
- [ ] the night sequence can't be dragged or resized beyond the timeline bounds
- [ ] double clicking on the sky sequence brings you to the sequence view

### TimelineLayer:

- [ ] one can bring the background layer to the front via drag and drop and the tree is not visible afterwards
- [ ] the info labels change accordingly

### TimelineCursor:

- [ ] scrolls when scrolling in the interactive
- [ ] with open interactive, scroll position (and cursor position) may be changed with arrow keys

### Interactive:

- [ ] can be opened
- [ ] is scrollable
- [ ] can be loaded in the editor via drag and drop

### Sequence View:

- [ ] there are two OverviewLayers (one per Morph in the sequence)
- [ ] they hold four Keyframes each
- [ ] right-clicking a keyframe shows a context menu
- [ ] clicking on the triangle expands those into two new layers with two keyframes each
- [ ] when expanding both morphs the cursor is still visible over all layers
- [ ] creating a new keyframe (with the inspector) will update the layers accordingly
- [ ] pressing ESC brings one back to the GlobalTimeline

### Inspector:

- [ ] the tree leaves can be selected to inspect with the target selector
- [ ] correct values for position, extent and opacity are shown
- [ ] when setting two keyframes for different position values at different scroll positions, an animation is created and can be viewed
- [ ] when scrolling in the scrollytelling, created keyframes are shown by a different icon in the inspector
- [ ] a keyframe can be overwritten in the inspector by navigating to the same scroll position (most easily done at scroll position 0) and adding a new keyframe

