### PR TITLE
Animate properties marked as 'animateAs'

### DIFF
--- a/editor.js
+++ b/editor.js
@@ -38,6 +38,8 @@ export class InteractivesEditor extends Morph {
       },
       globalTimeline: {
       },
+      inspector: {
+      },
       interactiveScrollPosition: {
         defaultValue: 0
       }
@@ -61,13 +63,13 @@ export class InteractivesEditor extends Morph {
     this.preview.initialize(this);
     this.addMorph(this.preview);
 
-    this.morphInspector = new InteractiveMorphInspector({
+    this.inspector = new InteractiveMorphInspector({
       position: pt(CONSTANTS.PREVIEW_WIDTH + CONSTANTS.SIDEBAR_WIDTH, 0),
       extent: pt(CONSTANTS.SIDEBAR_WIDTH, CONSTANTS.SUBWINDOW_HEIGHT),
       borderWidth: CONSTANTS.BORDER_WIDTH
     });
-    this.morphInspector.initialize(this);
-    this.addMorph(this.morphInspector);
+    this.inspector.initialize(this);
+    this.addMorph(this.inspector);
 
     this.menuBar = new MenuBar({ position: pt(0, CONSTANTS.SUBWINDOW_HEIGHT) });
     this.menuBar.initialize(this);

--- a/inspector.js
+++ b/inspector.js
@@ -91,9 +91,11 @@ export class InteractiveMorphInspector extends Morph {
   }
 
   get propertiesToDisplay () {
-    const defaultProperties = Object.entries(this.defaultProperties);
-    const defaultPropertiesInMorph = defaultProperties.filter(propertyAndType => propertyAndType[0] in this.targetMorph);
-    const additionalProperties = Object.entries(this.targetMorph.propertiesAndPropertySettings().properties).filter(propertyAndSettings => 'animateAs' in propertyAndSettings[1]).map(propertyAndSettings => [propertyAndSettings[0], propertyAndSettings[1].animateAs]);
+    const defaultPropertiesInMorph = Object.entries(this.defaultProperties)
+      .filter(propertyAndType => propertyAndType[0] in this.targetMorph);
+    const additionalProperties = Object.entries(this.targetMorph.propertiesAndPropertySettings().properties)
+      .filter(propertyAndSettings => 'animateAs' in propertyAndSettings[1])
+      .map(propertyAndSettings => [propertyAndSettings[0], propertyAndSettings[1].animateAs]);
     const propertyList = defaultPropertiesInMorph.concat(additionalProperties);
     return Object.fromEntries(propertyList);
   }

--- a/tests/inspector-test.js
+++ b/tests/inspector-test.js
@@ -1,0 +1,48 @@
+/* global it, describe, before, after */
+import { expect } from 'mocha-es6';
+import { Morph } from 'lively.morphic';
+import { Interactive, InteractivesEditor } from 'interactives-editor';
+
+class InspectorTestMorph extends Morph {
+  static get properties () {
+    return {
+      testProp: {
+        animateAs: 'number',
+        defaultValue: 0
+      },
+      testProp2: {
+
+      }
+    };
+  }
+}
+
+describe('Inspector', () => {
+  let morph, editor, interactive, inspector;
+  before(async () => {
+    editor = await new InteractivesEditor().initialize();
+    interactive = Interactive.example();
+    editor.interactive = interactive;
+    morph = new InspectorTestMorph();
+    inspector = editor.inspector;
+    interactive.sequences[0].addMorph(morph);
+    inspector.targetMorph = morph;
+  });
+
+  it('can animate a predefined property', () => {
+    expect('opacity' in inspector.propertiesToDisplay).to.be.ok;
+  });
+
+  it('can animate a property defined as animateAs', () => {
+    expect('testProp' in inspector.propertiesToDisplay).to.be.ok;
+    expect(inspector.propertiesToDisplay.testProp).to.equal('number');
+  });
+
+  it('can not animate a new property not defined as animateAs', () => {
+    expect('testProp2' in inspector.propertiesToDisplay).to.not.be.ok;
+  });
+
+  after(() => {
+    editor.owner.remove();
+  });
+});


### PR DESCRIPTION
Closes #214 

- [ ] I have added additional features that should now be part of the PR template. I made the necessary changes to the template.
- [ ] I have fixed a bug/the added functionality should not be part of the PR template.

## Features that still work:
### Sequences in GlobalTimeline:

- [ ] the tree sequence is resizeable both left and right
- [ ] the day sequence can't be dragged or resized onto the night sequence, instead it will snap to the night sequence and the snap indicator is shown
- [ ] the day sequence can be dragged to the middle layer, it will snap onto the tree sequence
- [ ] the night sequence can't be dragged or resized beyond the timeline bounds
- [ ] double clicking on the sky sequence brings you to a new tab named 'sky sequence' containing with the sequence view
- [ ] when clicking the "+" button a sequence is in the hand, which can only be dropped on a timelinelayer and changes color when you are not able to place the sequence
- [ ] right clicking on a sequence brings up a context menu

### TimelineLayer:

- [ ] one can bring the background layer to the front via drag and drop and the tree is not visible afterwards
- [ ] the info labels change accordingly

### TimelineCursor:

- [ ] scrolls when scrolling in the interactive
- [ ] with open interactive, scroll position (and cursor position) may be changed with arrow keys

### Interactive:

- [ ] can be opened
- [ ] is scrollable
- [ ] can be loaded in the editor via drag and drop

### Sequence View:

- [ ] there are three OverviewLayers (one per Morph in the sky sequence)
- [ ] they hold four to six keyframes each
- [ ] right-clicking a keyframe shows a context menu
- [ ] clicking on the triangle expands those into two new layers with two keyframes each
- [ ] when expanding both morphs the cursor is still visible over all layers
- [ ] creating a new keyframe (with the inspector) will update the layers accordingly
- [ ] clicking on a layer will select the corresponding morph in the inspector
- [ ] clicking on the first tab brings you back to the global timeline
- [ ] after scrolling in the global timeline, the cursor position in the already opened 'sky sequence' has updated as well, when changing to this tab and vice versa

### Inspector:

- [ ] the tree leaves can be selected to inspect with the target selector
- [ ] in the sequence view, a morph that is not part of the currently open sequence cannot be selected with the target picker
- [ ] correct values for position, extent and opacity are shown
- [ ] when setting two keyframes for different position values at different scroll positions, an animation is created and can be viewed
- [ ] when scrolling in the scrollytelling, created keyframes are shown by a different icon in the inspector
- [ ] a keyframe can be overwritten in the inspector by navigating to the same scroll position (most easily done at scroll position 0) and adding a new keyframe

### Tabs
- [ ] the first tab can be renamed to 'aScrollytelling', this will also rename the interactive to 'aScrollytelling'
- [ ] the second tab can be renamed to 'sunrise', this will also rename the sequence in the global timeline to 'sunrise' and the respective timeline to 'sunrise timeline'
- [ ] the second tab can be closed with the 'X'
