### PR TITLE
Connect keyframe buttons to editor, fix connection leak

### DIFF
--- a/inspector.js
+++ b/inspector.js
@@ -104,7 +104,7 @@ export class InteractiveMorphInspector extends Morph {
     if (!this.targetMorph) {
       return;
     }
-    this.ui.propertyPane.submorphs.forEach(morph => morph.remove());
+    this.ui.propertyPane.submorphs.forEach(morph => morph.withAllSubmorphsDo(submorph => submorph.remove()));
     const props = Object.keys(this.propertiesToDisplay);
     props.forEach(propToInspect => {
       const propType = this.propertiesToDisplay[propToInspect];
@@ -358,13 +358,13 @@ class KeyframeButton extends Morph {
       },
       inspector: { },
       animation: { },
-      _editor: {},
-      sequence: {
-        set (sequence) {
-          connect(sequence, 'updateProgress', this, 'updateStyle');
-          this.setProperty('sequence', sequence);
+      _editor: {
+        set (_editor) {
+          connect(_editor, 'interactiveScrollPosition', this, 'updateStyle');
+          this.setProperty('_editor', _editor);
         }
       },
+      sequence: {},
       property: {
         set (prop) {
           this.setProperty('property', prop);
@@ -460,5 +460,10 @@ class KeyframeButton extends Morph {
       this.setDefaultStyle();
     }
     this._updatingStyle = false;
+  }
+
+  remove () {
+    if (this.editor) disconnect(this.editor, 'interactiveScrollPosition', this, 'updateStyle');
+    super.remove();
   }
 }


### PR DESCRIPTION
Closes #236 

- [ ] I have added additional features that should now be part of the PR template. I made the necessary changes to the template.
- [x] I have fixed a bug/the added functionality should not be part of the PR template.
- [ ] I have run all our tests and they still work

### Inspector:

- [x] the tree leaves can be selected to inspect with the target selector
- [x] in the sequence view, a morph that is not part of the currently open sequence cannot be selected with the target picker
- [x] correct values for position, extent and opacity are shown
- [ ] when setting two keyframes for different position values at different scroll positions, an animation is created and can be viewed
- [x] when scrolling in the scrollytelling, created keyframes are shown by a different icon in the inspector
- [x] a keyframe can be overwritten in the inspector by navigating to the same scroll position (most easily done at scroll position 0) and adding a new keyframe
