### PR TITLE
Fix jumping on opening new tab

### DIFF
--- a/editor.js
+++ b/editor.js
@@ -273,6 +273,8 @@ export class InteractivesEditor extends Morph {
     }
     connect(displayedTimeline, 'zoomFactor', this.menuBar.ui.zoomInput, 'number', { converter: '(zoomFactor) => zoomFactor * 100' });
 
+    this.interactive.scrollOverlay.scroll = pt(0, this.interactive.scrollPosition);
+
     displayedTimeline.onScrollChange(this.interactiveScrollPosition);
 
     return displayedTimeline;


### PR DESCRIPTION
Closes #280

Using the same fix already used for arrow keys. This seems to be some race condition. Perhaps we should get Robin to look at it.

- [ ] I have added additional features that should now be part of the PR template. I made the necessary changes to the template.
- [x] I have fixed a bug/the added functionality should not be part of the PR template.
- [ ] I have run all our tests and they still work
