### PR TITLE
Don't rebuild inspector for the same morph

### DIFF
--- a/inspector.js
+++ b/inspector.js
@@ -38,7 +38,7 @@ export class InteractiveMorphInspector extends Morph {
       },
       targetMorph: {
         set (morph) {
-          if (morph) {
+          if (morph && morph != this.targetMorph) {
             this.disbandConnections();
             this.setProperty('targetMorph', morph);
             this.ui.headline.textString = `Inspecting ${morph.toString()}`;


### PR DESCRIPTION
There are a lot of ways to redraw the inspector nowadays: target selector, halo, layer click... And it always takes some time. This PR will stop unnecessary rebuilds.