### PR TITLE
Set zoom factor minimum dynamically according to shortest sequence

### DIFF
--- a/editor.js
+++ b/editor.js
@@ -279,6 +279,11 @@ export class InteractivesEditor extends Morph {
   }
 
   onZoomChange (newZoom) {
+    if (newZoom < this.displayedTimeline.minZoomFactor) {
+      this.menuBar.ui.zoomInput.number = this.displayedTimeline.minZoomFactor * 100;
+      this.displayedTimeline.zoomFactor = this.displayedTimeline.minZoomFactor;
+      return;
+    }
     this.displayedTimeline.zoomFactor = newZoom;
   }
 

--- a/timeline/index.js
+++ b/timeline/index.js
@@ -27,7 +27,7 @@ export class Timeline extends Morph {
         isFloat: true,
         min: 0,
         set (zoomFactor) {
-          if (zoomFactor <= 0) return;
+          if (zoomFactor < this.minZoomFactor) return;
           this.setProperty('zoomFactor', zoomFactor);
           if (!this.editor.interactive) return;
           this.redraw();
@@ -183,6 +183,10 @@ export class Timeline extends Morph {
     throw new Error('Subclass resposibility');
   }
 
+  get minZoomFactor () {
+    return 0.01;
+  }
+
   abandon () {
     disconnect(this.editor, 'interactiveScrollPosition', this, 'onScrollChange');
     disconnect(this.editor.interactive, 'name', this, 'name');
@@ -282,6 +286,11 @@ export class GlobalTimeline extends Timeline {
     this.timelineLayers.forEach(timelineLayer => {
       timelineLayer.deselectAllSequences();
     });
+  }
+
+  get minZoomFactor () {
+    const minSequenceDuration = Math.min(...this._editor.interactive.sequences.map(sequence => sequence.duration));
+    return Math.max(super.minZoomFactor, CONSTANTS.MINIMAL_SEQUENCE_WIDTH / minSequenceDuration);
   }
 }
 


### PR DESCRIPTION
Closes #281

- [ ] I have added additional features that should now be part of the PR template. I made the necessary changes to the template.
- [x] I have fixed a bug/the added functionality should not be part of the PR template.
- [ ] I have run all our tests and they still work

## Features that still work:
### Sequences in GlobalTimeline:

- [ ] the tree sequence is resizeable both left and right, this can be reversed
- [ ] the day sequence can't be dragged or resized onto the night sequence, instead it will snap to the night sequence and the snap indicator is shown
- [ ] the day sequence can be dragged to the middle layer, it will snap onto the tree sequence
- [ ] the night sequence can't be dragged or resized beyond the left timeline bounds
- [ ] double clicking on the sky sequence brings you to a new tab named 'sky sequence' containing the sequence view
- [ ] when clicking the "+" button a sequence is in the hand, which can only be dropped on a timelinelayer and changes color when you are not able to place the sequence
	- [ ] this can be cancelled by pressing ESC
- [ ] right clicking on a sequence brings up a context menu
- [ ] clicking the buttons in the MenuBar sets the ScrollPosition to the beginning/end of the interactive/beginning of the next/previous sequence
- [ ] moving a sequence to the right will make the active area (light grey) larger
- [ ] When making the zoom factor higher/lower with the input field, the length of the sequences adapt accordingly, the cursor updates its position and the whole scrollytelling can still be scrolled through

### TimelineLayer:

- [ ] one can bring the background layer to the front via drag and drop and the tree is not visible afterwards
- [ ] the info labels change accordingly
- [ ] a layer can be hidden with a click on the eye icon. The sequences in that layer will no longer be shown in the interactive

### TimelineCursor:

- [ ] scrolls when scrolling in the interactive
- [ ] with open interactive, scroll position (and cursor position) may be changed with arrow keys
- [ ] the number in the menubar is consistent with the cursorposition

### Interactive:

- [ ] can be opened
- [ ] is scrollable

### Interactive and editor:

- [ ] can be loaded in the editor via drag and drop
- [ ] a new scrollytelling can be created with a button
- [ ] resizing the interactive resizes the interactive (by a fixed aspect ratio)
- [ ] after resizing to have a bigger interactive the sun is bigger and still moves to about half of the interactive width

### Sequence View:

- [ ] there are three OverviewLayers (one per Morph in the sky sequence)
- [ ] they hold four to six keyframes each
- [ ] right-clicking a keyframe shows a context menu
	- [ ] right-clicking on the last keyframe of the sun's position animation, an option to select easing is shown
	- [ ] when clicked, a list of easings appears
	- [ ] when outBack is selected as the easing, the sun moves a little back at the end of the animation
- [ ] clicking on the triangle expands those into two new layers with two keyframes each
- [ ] when expanding both morphs the cursor is still visible over all layers
- [ ] creating a new keyframe (with the inspector) will update the layers accordingly
- [ ] clicking on a layer will select the corresponding morph in the inspector
- [ ] clicking on the first tab brings you back to the global timeline
- [ ] after scrolling in the global timeline, the cursor position in the already opened 'sky sequence' has updated as well, when changing to this tab and vice versa
- [ ] clicking the buttons in the MenuBar sets the ScrollPosition to the beginning/end of the sequence and to the prev/next keyframe
- [ ] When making the zoom factor higher/lower with the input field, the length of the active area adapt accordingly as well as the position of the keyframes and the cursor updates its position

### Inspector:

- [ ] the tree leaves can be selected to inspect with the target selector
- [ ] in the sequence view, a morph that is not part of the currently open sequence cannot be selected with the target picker
- [ ] when selecting a morph in the sequence via halo, that morph is shown in the inspector
- [ ] correct values for position, extent and opacity are shown
- [ ] when setting two keyframes for different position values at different scroll positions, an animation is created and can be viewed
- [ ] when scrolling in the scrollytelling, created keyframes are shown by a different icon in the inspector
- [ ] a keyframe can be overwritten in the inspector by navigating to the same scroll position (most easily done at scroll position 0) and adding a new keyframe

### Tabs
- [ ] the first tab can be renamed to 'aScrollytelling', this will also rename the interactive to 'aScrollytelling'
- [ ] the second tab can be renamed to 'sunrise', this will also rename the sequence in the global timeline to 'sunrise' and the respective timeline to 'sunrise timeline'
- [ ] the second tab can be closed with the 'X'
- [ ] opening two tabs and setting them to different zoom factors works as expected, even when changing between them and scrolling in both (the cursor is always at the correct position, both have independent zoom factors)
