### PR TITLE
Only assign reviewers when a PR is ready

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,9 +1,10 @@
 name: pull-request
 on:
   pull_request:
-    types: [opened, reopened]
+    types: [ready_for_review, reopened, opened]
 jobs:
   assign:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - uses: delivery-much/actions-assigner@v1


### PR DESCRIPTION
I got really annoyed because I got notifications all the time because the bot assigned me already as a reviewer to draft PRs.

My suggestion is running that job only for PRs that are ready for review. What do you think?
Also - I am super sorry for the PR spam, I had to test it :see_no_evil: