### PR TITLE
Change import from qinoq to import from ./index.js

### DIFF
--- a/animations.js
+++ b/animations.js
@@ -1,6 +1,6 @@
 import { pt } from 'lively.graphics';
 import { arr } from 'lively.lang';
-import { Sequence } from 'qinoq';
+import { Sequence } from './index';
 import { easings, stringToEasing } from 'lively.morphic';
 import { animatedProperties } from './properties.js';
 

--- a/editor.js
+++ b/editor.js
@@ -6,7 +6,7 @@ import { InteractiveMorphInspector } from './inspector.js';
 import { resource } from 'lively.resources';
 import { arr } from 'lively.lang';
 import { GlobalTimeline, SequenceTimeline } from './timeline/index.js';
-import { Sequence, Interactive, Layer } from 'qinoq';
+import { Sequence, Interactive, Layer } from './index.js';
 import { NumberWidget } from 'lively.ide/value-widgets.js';
 import { Button } from 'lively.components';
 

--- a/inspector.js
+++ b/inspector.js
@@ -6,7 +6,7 @@ import { Button } from 'lively.components';
 import { InteractiveMorphSelector } from 'lively.halos';
 import { disconnect, connect } from 'lively.bindings';
 import { ColorPickerField } from 'lively.ide/styling/color-picker.js';
-import { Sequence, Keyframe } from 'qinoq';
+import { Sequence, Keyframe } from './index.js';
 import { animatedPropertiesAndTypes } from './properties.js';
 
 const CONSTANTS = {

--- a/interactive.js
+++ b/interactive.js
@@ -3,7 +3,7 @@ import { Color, pt } from 'lively.graphics';
 import { connect, disconnect, signal, disconnectAll } from 'lively.bindings';
 import { newUUID } from 'lively.lang/string.js';
 import { COLOR_SCHEME } from './colors.js';
-import { Keyframe, createAnimationForPropertyType, NumberAnimation, PointAnimation, ColorAnimation } from 'qinoq';
+import { Keyframe, createAnimationForPropertyType, NumberAnimation, PointAnimation, ColorAnimation } from './index.js';
 import { LottieMorph } from './interactive-morphs/lottie-morph.js';
 import { arr } from 'lively.lang';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,7 @@
 {
   "name": "qinoq",
   "version": "0.1.0",
-  "lockfileVersion": 3,
+  "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {

--- a/timeline/index.js
+++ b/timeline/index.js
@@ -10,8 +10,8 @@ import { TimelineLayerInfo } from './layer-info.js';
 import { COLOR_SCHEME } from '../colors.js';
 import { arr } from 'lively.lang';
 import { ListPrompt } from 'lively.components/prompts.js';
-import { Keyframe, Sequence } from 'qinoq';
 import { singleSelectKeyPressed, zoomKeyPressed } from '../keys.js';
+import { Keyframe, Sequence } from './index.js';
 
 export class Timeline extends Morph {
   static get properties () {


### PR DESCRIPTION

for lively it is ok to write imports like `import { Sequence } from ' qinoq'` but all other js frameworks will error on this... thus I changed the imports I found to './index.js`
