### PR TITLE
Make crown morph bundleble

### DIFF
--- a/examples.js
+++ b/examples.js
@@ -126,6 +126,15 @@ class CloudMorph extends Image {
 }
 
 class CrownMorph extends Polygon {
+  constructor (props) {
+    // freezing breaks this class and will while deserialization not give any props which the class polygon can't take
+    // it will while deserialization set the vertices to the property values so those are
+    if (typeof props === 'undefined') {
+      props = { vertices: [pt(0, 0), pt(0, 0), pt(0, 0)] };
+    }
+    super(props);
+  }
+
   onMouseDown () {
     this.fill = this.fill.darker();
   }


### PR DESCRIPTION
Co-authored-by: merryman <merryman@users.noreply.github.com>

the problem is that the bundler only saves classes which are lively core modules and which are object editor classes. Other will be weirdly handled. Since the bundler changes the class definition their we do not get any props in the constructor. Images seem to be able to handle that while polygons seem to not be able to handle that.

Closes #546 

- [ ] I have added additional features that should now be part of the PR template. I made the necessary changes to the template.
- [x] I have fixed a bug/the added functionality should not be part of the PR template.
  - [ ] I added a test/ tests
- [ ] I have run all our tests and they still work
