### PR TITLE
Remove create timeline layer in sequence timeline

### DIFF
--- a/timeline/index.js
+++ b/timeline/index.js
@@ -625,15 +625,6 @@ export class SequenceTimeline extends Timeline {
     return timelineLayer;
   }
 
-  createTimelineLayer (morph, index = 0, name = undefined) {
-    const timelineLayer = super.createTimelineLayer(morph, index, name);
-    this.ui.layerInfoContainer.submorphs[timelineLayer.index].onMouseUp = () => {
-      if (morph.world()) morph.show();
-      this.editor.ui.inspector.targetMorph = morph;
-    };
-    return timelineLayer;
-  }
-
   onLoadContent (sequence) {
     this._sequence = sequence;
     this.sequence.submorphs.forEach(morph => {


### PR DESCRIPTION
This method seems useless to me. What does it do?
- It calls super.createTimelineLayer with the exact same arguments
- It adds a onMouseUp for the layerInfo. This can not be serialized, so if we want to keep that behavior we have to move it to layer info anyway. I think this onMouseUp is not even necessary, since the layer info already allows opening the inspector via right click and otherwise just click on the layer and open the inspector that way
- It returns the new layer

So after removing the onMouseUp action, this can be removed as it is equivalent to just calling the super class method