### PR TITLE
Fix/floating point number widgets

### DIFF
--- a/editor.js
+++ b/editor.js
@@ -904,7 +904,10 @@ class MenuBar extends QinoqMorph {
       dropShadow: false,
       borderWidth: 2,
       unit: '%',
-      borderColor: COLOR_SCHEME.SECONDARY
+      borderColor: COLOR_SCHEME.SECONDARY,
+      // Scale factor != 1 is necessary for floatingPoint to not be true (NumberWidget)
+      floatingPoint: false,
+      scaleFactor: 1.000000000000001 // smallest number greater than 1, not equal to 1 in JS
     });
     this.ui.zoomInput.getSubmorphNamed('value').fontColor = COLOR_SCHEME.ON_SURFACE;
     connect(this.ui.zoomInput, 'number', this.editor, 'onZoomChange', { converter: '(percent) => percent/100' });
@@ -920,7 +923,10 @@ class MenuBar extends QinoqMorph {
       tooltip: 'Set scroll position',
       dropShadow: false,
       borderWidth: 2,
-      borderColor: COLOR_SCHEME.SECONDARY
+      borderColor: COLOR_SCHEME.SECONDARY,
+      // Scale factor != 1 is necessary for floatingPoint to not be true (NumberWidget)
+      floatingPoint: false,
+      scaleFactor: 1.000000000000001
     });
     this.ui.scrollPositionInput.getSubmorphNamed('value').fontColor = COLOR_SCHEME.ON_SURFACE;
     connect(this.ui.scrollPositionInput, 'number', this.editor, 'onInternalScrollChange');
@@ -959,13 +965,6 @@ class MenuBar extends QinoqMorph {
     this.ui.addLayerButton.fontColor = COLOR_SCHEME.ON_BACKGROUND_VARIANT;
     this.ui.gotoNextButton.tooltip = 'Go to next keyframe';
     this.ui.gotoPrevButton.tooltip = 'Go to previous keyframe';
-  }
-
-  __after_deserialize__ (snapshot, ref, pool) {
-    // floatingPoint property is not properly serialized and needs to be set here again
-    this.ui.zoomInput.floatingPoint = false;
-    this.ui.scrollPositionInput.floatingPoint = false;
-    super.__after_deserialize__(snapshot, ref, pool);
   }
 }
 

--- a/inspector.js
+++ b/inspector.js
@@ -144,7 +144,7 @@ export class InteractiveMorphInspector extends QinoqMorph {
       position: pt(CONSTANTS.WIDGET_X, CONSTANTS.WIDGET_ONE_Y),
       extent: CONSTANTS.WIDGET_EXTENT,
       autofit: false,
-      scaleFactor: 1.01, // Has to be different than 1 to disable floatingPoint
+      scaleFactor: 1.000000000000001, // Has to be different than 1 to disable floatingPoint
       floatingPoint: false
     });
     this.propertyControls[property].y = new NumberWidget({
@@ -173,7 +173,7 @@ export class InteractiveMorphInspector extends QinoqMorph {
     this.propertyControls[property].number = new NumberWidget({
       position: pt(CONSTANTS.WIDGET_X, CONSTANTS.WIDGET_ONE_Y),
       floatingPoint,
-      scaleFactor: 1.01, // Has to be different than 1 to disable floatingPoint
+      scaleFactor: 1.000000000000001, // Has to be different than 1 to disable floatingPoint
       unit,
       min,
       max,


### PR DESCRIPTION
Closes #636

So NumberWidgets think they are smart but actually mess things up. This is the property definition

```js
floatingPoint: {
        after: ['number', 'submorphs'],
        set (isFloat) {
          this.setProperty('floatingPoint', isFloat);
          this.get('value').floatingPoint = isFloat;
        },
        get () {
          const m = /[+-]?([0-9]*[.])?[0-9]+/.exec(this.number);
          return this.getProperty('floatingPoint') || (this.scaleFactor == 1 && m && !!m[1]);
        }
      }
```
The regex is always true for our use cases (because the underlying number is a float, even when not visible), so if the property floatingPoint is not set true it is ignored and if scaleFactor is 1, it will always be floatingPoint true

- [ ] I have added additional features that should now be part of the PR template. I made the necessary changes to the template.
- [x] I have fixed a bug/the added functionality should not be part of the PR template.
  - [ ] I added a test/ tests
- [x] I have run all our tests and they still work