### PR TITLE
Use first value for string keyframes with no interpolation

### DIFF
--- a/animations.js
+++ b/animations.js
@@ -241,7 +241,7 @@ export class TypewriterAnimation extends Animation {
     if (start.value.startsWith(end.value)) {
       return 'reverse';
     }
-    $world.setStatusMessage('Can not animate the string transition. Can only interpolate between two strings if the start or end of the strings match!');
+    return 'no-interpolation';
   }
 
   interpolate (progress, start, end) {
@@ -256,6 +256,8 @@ export class TypewriterAnimation extends Animation {
         return `${start.value}${end.value.slice(start.value.length, start.value.length + shownChars)}`;
       case 'reverse':
         return `${end.value}${start.value.slice(end.value.length, start.value.length - shownChars)}`;
+      case 'no-interpolation':
+        return start.value;
     }
   }
 

--- a/tests/animation-test.js
+++ b/tests/animation-test.js
@@ -96,7 +96,7 @@ describe('Typewriter animation', () => {
     stringAnimation.progress = 0;
     expect(mockMorph.textString).to.be.equal(string1);
     stringAnimation.progress = 0.5;
-    expect(mockMorph.textString).to.be.undefined;
+    expect(mockMorph.textString).to.be.equal(string1);
     stringAnimation.progress = 1;
     expect(mockMorph.textString).to.be.equal(string3);
   });


### PR DESCRIPTION
Closes #707 

- [ ] I have added additional features that should now be part of the PR template. I made the necessary changes to the template.
- [x] I have fixed a bug/the added functionality should not be part of the PR template.
  - [ ] I added a test/ tests.
- [x] I have run all our tests and they still work.