### PR TITLE
Check whether undo is already in progress to fix grab halo

### DIFF
--- a/editor.js
+++ b/editor.js
@@ -505,6 +505,8 @@ export class InteractivesEditor extends QinoqMorph {
 
   onZoomChange (newZoom) {
     let undo;
+    // when grabbing in sequence view an undo is already in progress
+    // a new undo might destroy the grab halo
     if (!this.env.undoManager.undoInProgress) { undo = this.undoStart('interactive-editor-change-zoom'); }
     this.displayedTimeline.zoomFactor = newZoom;
     if (undo) this.undoStop('interactive-editor-change-zoom');


### PR DESCRIPTION
Closes #734 

- [ ] I have added additional features that should now be part of the PR template. I made the necessary changes to the template.
- [x] I have fixed a bug/the added functionality should not be part of the PR template.
  - [ ] I added a test/ tests.
- [x] I have run all our tests and they still work.

this just checks whether we already record an undo, which is the case while grabbing. somehow this seems to destroy the grab undo and the grab halo is not able to stop correctly. When being in sequence view we change zoom while changing tabs but there is no possibility to also record this change while being in undo and I do not think it makes a lot of sense to record the undo here anyways.