### PR TITLE
Fix keyframes not snapping after loading saved world

### DIFF
--- a/animations.js
+++ b/animations.js
@@ -157,7 +157,7 @@ export function createAnimationForPropertyType (propertyType, targetMorph, prope
 export class Keyframe {
   constructor (position, value, spec = {}) {
     const { name = 'aKeyframe', easing = 'inOutSine' } = spec;
-    this.id = newUUID();
+    this.uuid = newUUID();
     this.position = position;
     this.value = value;
     this.name = name;
@@ -182,7 +182,7 @@ export class Keyframe {
   }
 
   equals (keyframe) {
-    return this.id === keyframe.id;
+    return this.uuid === keyframe.uuid;
   }
 
   copy () {

--- a/interactive.js
+++ b/interactive.js
@@ -565,11 +565,11 @@ export class Layer {
     this.name = name;
     this.hidden = hidden;
     this._zIndex = zIndex;
-    this.id = newUUID();
+    this.uuid = newUUID();
   }
 
   equals (layer) {
-    return this.id === layer.id;
+    return this.uuid === layer.uuid;
   }
 }
 


### PR DESCRIPTION
Closes #856

- [ ] I have added additional features that should now be part of the PR template. I made the necessary changes to the template.
- [x] I have fixed a bug/the added functionality should not be part of the PR template.
  - [ ] I added a test/ tests.
- [ ] I have run all our tests and they still work.

Id properties on objects do not survive deserialization (reasons unclear), so these properties needed to be renamed.