### PR TITLE
Move rejecting Drops on Interactive when not in Sequence View to Editor

### DIFF
--- a/editor.js
+++ b/editor.js
@@ -230,6 +230,7 @@ export class InteractivesEditor extends QinoqMorph {
     connect(this.interactive, 'interactiveZoomed', this, 'onInteractiveZoomed');
 
     connect(this.interactive.scrollOverlay, 'newMorph', this, 'addMorphToInteractive');
+    connect(this.interactive.scrollOverlay, 'rejectDrop', this, 'rejectDropOnInteractive');
 
     // trigger update of timeline dependents
     this.onDisplayedTimelineChange(this.ui.globalTimeline);
@@ -314,6 +315,7 @@ export class InteractivesEditor extends QinoqMorph {
     disconnect(this.interactive, '_length', this.ui.menuBar.ui.scrollPositionInput, 'max');
 
     disconnect(this.interactive.scrollOverlay, 'newMorph', this, 'addMorphToInteractive');
+    disconnect(this.interactive.scrollOverlay, 'rejectDrop', this, 'rejectDropOnInteractive');
 
     const morphsToClear = [this.ui.tabContainer, this.ui.menuBar, this.ui.inspector, this.ui.interactiveGraph];
     morphsToClear.forEach(morph =>
@@ -455,6 +457,16 @@ export class InteractivesEditor extends QinoqMorph {
     newSequence.name = `copy of ${newSequence.name}`;
     this.interactive.addSequence(newSequence);
     const timelineSequence = this.ui.globalTimeline.createTimelineSequence(newSequence);
+  }
+
+  rejectDropOnInteractive (event) {
+    event.hand.grabbedMorphs.forEach(morph => {
+      const properties = event.hand._grabbedMorphProperties.get(morph);
+      properties.prevOwner.addMorph(morph);
+      morph.position = properties.prevPosition;
+      Object.assign(morph, properties.pointerAndShadow);
+    });
+    error('Only add in sequence view');
   }
 
   addMorphToInteractive (morph) {

--- a/interactive.js
+++ b/interactive.js
@@ -454,13 +454,8 @@ class InteractiveScrollHolder extends Morph {
   onDrop (event) {
     if (event.type != 'morphicdragend') return;
     if (!this.passThroughMorph) {
-      event.hand.grabbedMorphs.forEach(morph => {
-        const properties = event.hand._grabbedMorphProperties.get(morph);
-        properties.prevOwner.addMorph(morph);
-        morph.position = properties.prevPosition;
-        Object.assign(morph, properties.pointerAndShadow);
-      });
-      $world.setStatusMessage('Only add in sequence view');
+      signal(this, 'rejectDrop', event);
+      return;
     }
     event.hand.grabbedMorphs.forEach(grabbedMorph => {
       const { pointerAndShadow } = event.hand._grabbedMorphProperties.get(grabbedMorph) || {};


### PR DESCRIPTION
Co-authored-by: T4rikA <talnawa@outlook.de>


Closes #858

- [ ] I have added additional features that should now be part of the PR template. I made the necessary changes to the template.
- [x] I have fixed a bug/the added functionality should not be part of the PR template.
  - [ ] I added a test/ tests.
- [x] I have run all our tests and they still work. (Except the broken tests for the Inspector)