### PR TITLE
Fix errors on mouse move after bundling

### DIFF
--- a/interactive.js
+++ b/interactive.js
@@ -492,7 +492,7 @@ class InteractiveScrollHolder extends Morph {
         : this.nativeCursor = this.currentMouseTarget.nativeCursor;
     }
     if (this.previousMorphUnderMouse) {
-      this.previousMorphUnderMouse.onHoverOut({ hand: $world.firstHand });
+      this.previousMorphUnderMouse.onHoverOut({ hand: $world.firstHand, state: {} });
       this.tooltipViewer.hoverOutOfMorph(this.tooltipViewer.currentMorph);
     }
 


### PR DESCRIPTION
Closes #897

For not entirely clear reasons, the world is the morph beneath that is selected by the scroll holder in some cases ( I could produce it after bundling). onHoverOut on the world access evt.state.draggedMorph, so we have to set an empty state object.

- [ ] I have added additional features that should now be part of the PR template. I made the necessary changes to the template.
- [x] I have fixed a bug/the added functionality should not be part of the PR template.
  - [ ] I added a test/ tests.
- [ ] I have run all our tests and they still work.
