### PR TITLE
Target selector no longer triggers onMouseUp on targets

### DIFF
--- a/inspector/target-picker.js
+++ b/inspector/target-picker.js
@@ -37,8 +37,7 @@ export class TargetPicker extends Button {
     this.opacity = 1;
   }
 
-  async onMouseDown (event) {
-    super.onMouseDown(event);
+  async onMouseUp (event) {
     this.inspector.targetMorph = await InteractiveMorphSelector.selectMorph($world, null, morph => Sequence.getSequenceOfMorph(morph) && Sequence.getSequenceOfMorph(morph).focused);
   }
 }


### PR DESCRIPTION
Closes #910 

Requires https://github.com/LivelyKernel/lively.next/pull/291

- [ ] I have added additional features that should now be part of the PR template. I made the necessary changes to the template.
- [x] I have fixed a bug/the added functionality should not be part of the PR template.
  - [ ] I added a test/ tests.
- [ ] I have run all our tests and they still work.
