### PR TITLE
Fix failing editor tests due to morph name collisions

### DIFF
--- a/tests/editor-test.js
+++ b/tests/editor-test.js
@@ -112,11 +112,11 @@ describe('Editor', () => {
     it('inserts exactly one placeholder when last morph in sequence is removed', async () => {
       const dayBackgroundTimelineSequence = timelineSequences().find(timelineSequence => timelineSequence.sequence.name == 'day background');
       await dayBackgroundTimelineSequence.openSequenceView();
-      expect(editor.getSubmorphNamed('timeline placeholder')).to.not.be.ok;
+      expect(editor.getSubmorphNamed('layer placeholder')).to.not.be.ok;
       editor.removeMorphFromInteractive(dayBackgroundTimelineSequence.sequence.submorphs[0]);
-      expect(editor.getSubmorphNamed('timeline placeholder')).to.be.ok;
+      expect(editor.getSubmorphNamed('layer placeholder')).to.be.ok;
       const placeholders = [];
-      editor.withAllSubmorphsDo((submorph) => { if (submorph.name === 'timeline placeholder') placeholders.push(submorph); });
+      editor.withAllSubmorphsDo((submorph) => { if (submorph.name === 'layer placeholder') placeholders.push(submorph); });
       expect(placeholders.length).to.be.equal(1);
     });
 
@@ -125,14 +125,14 @@ describe('Editor', () => {
       dayBackgroundTimelineSequence.sequence.submorphs.forEach(submorph => submorph.remove());
       await dayBackgroundTimelineSequence.openSequenceView();
       editor.addMorphToInteractive(new Morph());
-      expect(editor.getSubmorphNamed('timeline placeholder')).to.not.be.ok;
+      expect(editor.getSubmorphNamed('layer placeholder')).to.not.be.ok;
     });
 
     it('does not insert placeholder when morph(s) remain in the sequence', async () => {
       const dayBackgroundTimelineSequence = timelineSequences().find(timelineSequence => timelineSequence.sequence.name == 'tree sequence');
       await dayBackgroundTimelineSequence.openSequenceView();
       editor.removeMorphFromInteractive(dayBackgroundTimelineSequence.sequence.submorphs[0]);
-      expect(editor.getSubmorphNamed('timeline placeholder')).to.not.be.ok;
+      expect(editor.getSubmorphNamed('layer placeholder')).to.not.be.ok;
     });
 
     it('a layer with keyframes can be expanded', async () => {

--- a/timeline/index.js
+++ b/timeline/index.js
@@ -794,9 +794,9 @@ export class SequenceTimeline extends Timeline {
   }
 
   addPlaceholder () {
-    if (this.getSubmorphNamed('timeline placeholder')) return;
+    if (this.getSubmorphNamed('layer placeholder')) return;
     const placeholder = new Morph({
-      name: 'timeline placeholder',
+      name: 'layer placeholder',
       fill: COLOR_SCHEME.BACKGROUND_VARIANT,
       opacity: 0.5,
       height: TIMELINE_CONSTANTS.SEQUENCE_LAYER_HEIGHT,
@@ -817,7 +817,7 @@ export class SequenceTimeline extends Timeline {
   }
 
   removePlaceholder () {
-    const placeholder = this.get('timeline placeholder');
+    const placeholder = this.get('layer placeholder');
     if (placeholder) placeholder.remove();
     this.ui.scrollableContainer.clipMode = 'auto';
   }


### PR DESCRIPTION
Closes #957

We checked for the existence of a morph named placeholder in multiple places in the code. The search field of the tree also holds a morph with that name. I have resolved the name collision.

All editor tests are green an run without error in a new world.