### PR TITLE
Fix bug with keyframe snapping over left timeline bounds

### DIFF
--- a/timeline/keyframe.js
+++ b/timeline/keyframe.js
@@ -218,13 +218,12 @@ export class TimelineKeyframe extends QinoqMorph {
       }
     });
 
-    this.handleSnapping(event.hand.dragKeyframeStates);
-
     if (!this.isValidDrag(event.hand.dragKeyframeStates)) {
       event.hand.dragKeyframeStates.forEach(stateForKeyframe => {
         stateForKeyframe.timelineKeyframe.position = stateForKeyframe.previousPosition;
       });
     } else {
+      this.handleSnapping(event.hand.dragKeyframeStates);
       event.hand.dragKeyframeStates.forEach(stateForKeyframe => {
         stateForKeyframe.previousPosition = stateForKeyframe.timelineKeyframe.position;
       });


### PR DESCRIPTION
Co-authored-by: Paula-Kli <Paula-Kli@users.noreply.github.com>

Timeline keyframes overshoot when dragging to the left

- [ ] I have added additional features that should now be part of the PR template. I made the necessary changes to the template.
- [x] I have fixed a bug/the added functionality should not be part of the PR template.
  - [ ] I added a test/ tests.
- [ ] I have run all our tests and they still work.