### PR TITLE
Use emojis for copy and halo in layer-info context menu

### DIFF
--- a/timeline/keyframe.js
+++ b/timeline/keyframe.js
@@ -113,7 +113,7 @@ export class TimelineKeyframe extends QinoqMorph {
     const multipleKeyframesSelected = this.timeline.selectedTimelineKeyframes.length > 1;
     return [
       ['✏️ Rename Selected Keyframes', async () => await this.timeline.promptRenameForSelection(multipleKeyframesSelected)],
-      ['❌ Delete Selected Keyframes', () => this.timeline.deleteSelectedItems()],
+      ['🗑️ Delete Selected Keyframes', () => this.timeline.deleteSelectedItems()],
       ['📏 Edit Selected Relative Keyframe Positions (0 to 1)', async () => { await this.timeline.promptUserForNewRelativePositionForSelection(multipleKeyframesSelected); }],
       ['📏 Edit Selected Absolute Keyframe Position', async () => { await this.timeline.promptUserForNewAbsolutePositionForSelection(multipleKeyframesSelected); }],
       ['📈 Set Easing for Selected Keyframes', () => this.timeline.promptEasingForSelection(multipleKeyframesSelected)]

--- a/timeline/layer-info.js
+++ b/timeline/layer-info.js
@@ -139,7 +139,7 @@ export class GlobalTimelineLayerInfo extends TimelineLayerInfo {
     if (this.timelineLayer.index < this.timelineLayer.highestIndex) {
       menuOptions.push(['⬇️ Move layer down', () => this.timelineLayer.moveLayerBy(1)]);
     }
-    menuOptions.push(['❌ Remove layer', async () => await this.promptRemoveLayer()]);
+    menuOptions.push(['🗑️ Remove layer', async () => await this.promptRemoveLayer()]);
 
     return menuOptions;
   }
@@ -219,10 +219,10 @@ export class SequenceTimelineLayerInfo extends TimelineLayerInfo {
       if (this.morph.world()) this.morph.show();
     }]);
     menuOptions.push(['✏️ Rename morph', async () => await this.promptMorphName()]);
-    menuOptions.push(['❌ Remove morph', async () => await this.abandonMorph()]);
-    menuOptions.push(['▭ Show halo for morph', () => $world.showHaloFor(this.morph)]);
+    menuOptions.push(['🗑️ Remove morph', async () => await this.abandonMorph()]);
+    menuOptions.push(['⏹️ Show halo for morph', () => $world.showHaloFor(this.morph)]);
     if (this.timelineLayer.isOverviewLayer) {
-      menuOptions.push(['🗐 Copy Morph', () => this.editor.copyMorph(this.morph)]);
+      menuOptions.push(['👥 Copy Morph', () => this.editor.copyMorph(this.morph)]);
       menuOptions.push(['✂️ Cut Morph', () => this.editor.cutMorph(this.morph)]);
       if (this.editor.clipboard.containsMorph) menuOptions.push(['✏️ Paste Morph', () => this.editor.pasteMorphFromClipboard()]);
       if (this.timelineLayer.mayBeExpanded) {


### PR DESCRIPTION
Closes #1032 

Using a blue square as proposed does not work, since lively makes basically what we previously had out of it.
The remove options has been changed for a consistent look.
